### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
    <img src="https://cloud.githubusercontent.com/assets/5885065/5642960/fbc4d352-9606-11e4-91fb-5f5c458b52d0.png"
  alt="algo Logo" title="algo" align="right" />
   
-   This is the Official Documentation of algo module. This API provides an implementation of different algorithms.  The algorithms library defines functions for a variety of purposes (e.g. data structures, searching, sorting, counting, manipulating data) that operate on ranges of elements. Provided algorithms were collected after one year research that analyzed the most commonly used algoithms in Software Engineering. The module was created in order to help Python developers to easily utilize those frequently used algorithms without having to implement them. Written algorithms include topics from different subfields of Computer Science. The current version of the module contains 50 algorithms. We are planning to increase the number of algorithms in the second version of this API.  It is important to note that the license of algo module is distributed under [Apache Licese] [web2].
+   This is the Official Documentation of algo module. This API provides an implementation of different algorithms.  The algorithms library defines functions for a variety of purposes (e.g. data structures, searching, sorting, counting, manipulating data) that operate on ranges of elements. Provided algorithms were collected after one year research that analyzed the most commonly used algorithms in Software Engineering. The module was created in order to help Python developers to easily utilize those frequently used algorithms without having to implement them. Written algorithms include topics from different subfields of Computer Science. The current version of the module contains 50 algorithms. We are planning to increase the number of algorithms in the second version of this API.  It is important to note that the license of algo module is distributed under [Apache Licese] [web2].
 
 ### Installation
 
@@ -78,7 +78,7 @@ A sorting algorithm is an algorithm that puts elements of a list(lst) in a certa
    
    6. Merge_Sort(lst) - For description read: http://en.wikipedia.org/wiki/Merge_sort
    
-   7. Quick_Sort(lst) - For descritopn read: http://en.wikipedia.org/wiki/Quicksort
+   7. Quick_Sort(lst) - For description read: http://en.wikipedia.org/wiki/Quicksort
    
 
 ##### HASHING ALGORITHMS
@@ -136,7 +136,7 @@ In computer science, a search algorithm is an algorithm for finding an item with
 
    4. find_max_subarray(numbers) - Finds the contiguous subarray within a one-dimensional array of numbers which has the largest sum.
 
-   5. permutations(l) - A generator that retursn all the permutations of the given list l.
+   5. permutations(l) - A generator that returns all the permutations of the given list l.
 
    6. is_polindrom(string) - Checks whether the given string is a polindrom or not.
 

--- a/algo.py
+++ b/algo.py
@@ -901,7 +901,7 @@ def find_max_subarray(numbers):
 """  30. LIST PERMUTATIONS            
 
 DEFINITION
-	This genrator returs all the permutations for the given list.
+	This generator returns all the permutations for the given list.
 """
 def permutations(l):
     """ Generator for list permutations. """


### PR DESCRIPTION
There are small typos in:
- README.md
- algo.py

Fixes:
- Should read `returns` rather than `retursn`.
- Should read `returns` rather than `returs`.
- Should read `generator` rather than `genrator`.
- Should read `description` rather than `descritopn`.
- Should read `algorithms` rather than `algoithms`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md